### PR TITLE
Requests spec can have 'string' in main describe block

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -13,6 +13,7 @@ RSpec/DescribeClass:
   Exclude:
     - spec/*
     - spec/features/**/*
+    - spec/requests/**/*
 RSpec/LetSetup:
   Enabled: false
 RSpec/MultipleExpectations:


### PR DESCRIPTION
Requests specs, like features hasn't an associated `described_class` so we can ignore it