### PR TITLE
Add rubocop-rails for rails application

### DIFF
--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -1,0 +1,3 @@
+inherit_from:
+  - https://raw.githubusercontent.com/leanpanda-com/rubocop/master/rubocop.yml
+  - https://raw.githubusercontent.com/leanpanda-com/rubocop/master/rubocop-rspec.yml


### PR DESCRIPTION
In a Rails application it's needed to include both rubocop.yml
and rubucop-rspec.yml.

Currently rubocop-rspec.yml inherit_from rubocop.yml, but inheriting from
rubocop-rspec could create a bit of confusion.

Having to include simply `rubocop-rspec` in rails projects avoid confusion