### PR TITLE
Allow the word 'and' in context prefix

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -9,6 +9,15 @@ Metrics/BlockLength:
     - shared_examples
     - shared_examples_for
 
+RSpec/ContextWording:
+  Prefixes:
+    - and
+    - for
+    - if
+    - unless
+    - when
+    - with
+    - without
 RSpec/DescribeClass:
   Exclude:
     - spec/*


### PR DESCRIPTION
The default configuration allow `for`, `if`, `unless`, `when`, `with`, `without`

Adding `and` could be useful in nested context

```
context "when some condition" do
  context "and some other condition" do
    ...
  end
end
```