### PR TITLE
Layout/AlignParameters: replace obsolate configuration

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - "node_modules/**/*"
   TargetRubyVersion: 2.3
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 Layout/DotPosition:
   EnforcedStyle: trailing


### PR DESCRIPTION
Replace Layout/AlignParameters with Layout/ParameterAlignment for Rubocop 0.79.0. Create a version tag for this change (for backward compatibility).