### PR TITLE
Merged configs - removing the inherit_from line

### DIFF
--- a/rubocop-rails.yml
+++ b/rubocop-rails.yml
@@ -1,18 +1,65 @@
-inherit_from:
-  - https://raw.githubusercontent.com/leanpanda-com/rubocop/master/rubocop.yml
-  - https://raw.githubusercontent.com/leanpanda-com/rubocop/master/rubocop-rspec.yml
+require: 
+  - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   Exclude:
-    - "bin/**/*"
-    - "db/schema.rb"
+    - bin/**/*
+    - db/schema.rb
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
 
 Metrics/AbcSize:
   Exclude:
-    - "db/migrate/*"
+    - db/migrate/*
 Metrics/BlockLength:
   Exclude:
-    - "db/seeds.rb"
+    - db/seeds.rb
+  ExcludedMethods:
+    - context
+    - describe
+    - feature
+    - shared_examples
+    - shared_examples_for
 Metrics/MethodLength:
   Exclude:
-    - "db/migrate/*"
+    - db/migrate/*
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+Style/Documentation:
+  Enabled: false
+Style/EmptyCaseCondition:
+  Enabled: false
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/Lambda:
+  EnforcedStyle: literal
+Style/NegatedIf:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/SymbolArray:
+  Enabled: false
+  
+RSpec/DescribeClass:
+  Exclude:
+    - spec/*
+    - spec/features/**/*
+    - spec/requests/**/*
+RSpec/LetSetup:
+  Enabled: false
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/features/**/*
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/NotToNot:
+  Enabled: false

--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -1,5 +1,19 @@
-inherit_from: https://raw.githubusercontent.com/leanpanda-com/rubocop/master/rubocop.yml
 require: rubocop-rspec
+
+AllCops:
+  Exclude:
+    - bin/**/*
+    - .bundle/**/*
+    - bundle/**/*
+    - node_modules/**/*
+  TargetRubyVersion: 2.3
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+Layout/DotPosition:
+  EnforcedStyle: trailing
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
 
 Metrics/BlockLength:
   ExcludedMethods:
@@ -8,6 +22,27 @@ Metrics/BlockLength:
     - feature
     - shared_examples
     - shared_examples_for
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+Style/Documentation:
+  Enabled: false
+Style/EmptyCaseCondition:
+  Enabled: false
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/Lambda:
+  EnforcedStyle: literal
+Style/NegatedIf:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/SymbolArray:
+  Enabled: false
 
 RSpec/DescribeClass:
   Exclude:
@@ -23,4 +58,3 @@ RSpec/NamedSubject:
   Enabled: false
 RSpec/NotToNot:
   Enabled: false
-


### PR DESCRIPTION
This PR removes the inherit_from from rubocop-rspec.yml and rubocop-rails.yml. 
This might be not right, I just merged following the rules (lower in the file, more priority).

For example, it seems the correct might be:
```
AllCops:
  Exclude:
    - "bin/**/*"
    - "db/schema.rb"
    - "bundle/**/*"
    - "node_modules/**/*"
```
instead of:
```
AllCops:
  Exclude:
    - "bin/**/*"
    - "db/schema.rb"
```

Also, it looks it might be better to have:
```
Metrics/BlockLength:
  ExcludedMethods:
    - context
    - describe
    - feature
    - shared_examples
    - shared_examples_for
    - namespace
    - draw
```

instead of:
```
Metrics/BlockLength:
  ExcludedMethods:
    - context
    - describe
    - feature
    - shared_examples
    - shared_examples_for
```